### PR TITLE
Bugfix leftover issues

### DIFF
--- a/src/api/rest/flask_app.py
+++ b/src/api/rest/flask_app.py
@@ -48,7 +48,10 @@ def create_app(api_keys=CONFIG["api_keys"]):
     @require_api_key
     def show_config():
         """Function that returns the config of this service."""
-        return json.dumps(CONFIG, indent=4)
+        config_info = CONFIG.copy()
+        # remove api_keys from config, as we don't want to show them
+        config_info.pop("api_keys")
+        return json.dumps(config_info, indent=4)
 
     @app.route("/health", methods=["GET"])
     @require_api_key

--- a/src/api/rest/flask_app.py
+++ b/src/api/rest/flask_app.py
@@ -87,7 +87,7 @@ def create_app(api_keys=CONFIG["api_keys"]):
         """API endpoint to get the status of a transcription"""
         file = DATA_HANDLER.get_status_file_by_id(transcription_id)
         if file:
-            return make_response(jsonify(file), 200, {"Content-Type": "application/json"})
+            return make_response(file, 200, {"Content-Type": "application/json"})
         return make_response("Transcription ID not found", 404)
 
     @app.route("/transcriptions", methods=["POST"])

--- a/src/api/rest/flask_app.py
+++ b/src/api/rest/flask_app.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime
 from functools import wraps
 from pydub import AudioSegment
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, make_response
 from src.helper.logger import Color, Logger
 from src.config import CONFIG
 from src.helper.types.transcription_status import (
@@ -25,6 +25,7 @@ def create_app(api_keys=CONFIG["api_keys"]):
     def require_api_key(func):
         """Decorator function to require an API key for a route"""
 
+        
         @wraps(func)
         def wrapper(*args, **kwargs):
             api_key = request.headers.get("key")
@@ -51,13 +52,13 @@ def create_app(api_keys=CONFIG["api_keys"]):
         config_info = CONFIG.copy()
         # remove api_keys from config, as we don't want to show them
         config_info.pop("api_keys")
-        return json.dumps(config_info, indent=4)
+        return make_response(json.dumps(config_info, indent=4), 200, {"Content-Type": "application/json"})
 
     @app.route("/health", methods=["GET"])
     @require_api_key
     def health_check():
         """return health status"""
-        return "OK"
+        return make_response("OK", 200)
 
     @app.route("/transcriptions", methods=["GET"])
     @require_api_key
@@ -78,7 +79,7 @@ def create_app(api_keys=CONFIG["api_keys"]):
             except Exception as e:
                 LOGGER.print_error(f"Error while reading status file {file_name}: {e}")
                 DATA_HANDLER.delete_status_file(file_name)
-        return jsonify(transcriptions)
+        return make_response(jsonify(transcriptions), 200, {"Content-Type": "application/json"})
 
     @app.route("/transcriptions/<transcription_id>", methods=["GET"])
     @require_api_key
@@ -86,8 +87,8 @@ def create_app(api_keys=CONFIG["api_keys"]):
         """API endpoint to get the status of a transcription"""
         file = DATA_HANDLER.get_status_file_by_id(transcription_id)
         if file:
-            return jsonify(file), 200
-        return "Transcription ID not found", 404
+            return make_response(jsonify(file), 200, {"Content-Type": "application/json"})
+        return make_response("Transcription ID not found", 404)
 
     @app.route("/transcriptions", methods=["POST"])
     @require_api_key
@@ -103,7 +104,7 @@ def create_app(api_keys=CONFIG["api_keys"]):
                     AudioSegment.from_file(file.stream), transcription_id
                 )
                 if result["success"] is not True:
-                    return jsonify(result["message"]), 400
+                    return make_response(jsonify(result["message"]), 400, {"Content-Type": "application/json"})
 
                 # sleep to make sure that the file is saved before the transcription starts
                 time.sleep(0.1)
@@ -124,10 +125,10 @@ def create_app(api_keys=CONFIG["api_keys"]):
                 }
 
                 DATA_HANDLER.write_status_file(transcription_id, data)
-                return jsonify(data), 200
+                return make_response(jsonify(data), 200, {"Content-Type": "application/json"})
 
         except Exception as e:
             LOGGER.print_error(f"Error while POST /transcriptions: {e}")
-        return "Something went wrong"
+        return make_response("Something went wrong", 500)
 
     return app

--- a/src/api/rest/test/test_flask_app.py
+++ b/src/api/rest/test/test_flask_app.py
@@ -33,10 +33,19 @@ def test_health_check(rest_client):
 def test_show_config(rest_client):
     """Test the show config endpoint"""
     response = rest_client.get("/", headers={"key": EXAMPLE_AUTH_KEY})
+    config_info = CONFIG.copy()
+    config_info.pop("api_keys")
     assert response.status_code == 200
-    assert response.data.decode("utf-8") == json.dumps(CONFIG, indent=4)
+    assert response.data.decode("utf-8") == json.dumps(config_info, indent=4)
     # make sure indent is right
-    assert response.data.decode("utf-8") != json.dumps(CONFIG, indent=2)
+    assert response.data.decode("utf-8") != json.dumps(config_info, indent=2)
+
+def test_show_config_without_api_keys(rest_client):
+    """Make sure the show config endpoint does not show api keys"""
+    response = rest_client.get("/", headers={"key": EXAMPLE_AUTH_KEY})
+    assert response.status_code == 200
+    assert "api_keys" not in response.data.decode("utf-8")
+    assert response.data.decode("utf-8") != json.dumps(CONFIG, indent=4)
 
 def test_show_config_unauthorized(rest_client):
     """Test the show config endpoint with an invalid auth key"""

--- a/src/api/rest/test/test_flask_app.py
+++ b/src/api/rest/test/test_flask_app.py
@@ -37,6 +37,7 @@ def test_show_config(rest_client):
     config_info.pop("api_keys")
     assert response.status_code == 200
     assert response.data.decode("utf-8") == json.dumps(config_info, indent=4)
+    assert response.headers["Content-Type"] == "application/json"
     # make sure indent is right
     assert response.data.decode("utf-8") != json.dumps(config_info, indent=2)
 
@@ -66,6 +67,7 @@ def test_post_transcription(rest_client, cleanup_data):
 
     response_dict = response.get_json()
 
+    assert response.headers["Content-Type"] == "application/json"
     assert response.status_code == 200
     assert response_dict["settings"] is None
     assert response_dict["status"] == "in_query"
@@ -119,6 +121,7 @@ def test_get_transcriptions_id(rest_client, cleanup_data):
         f"/transcriptions/{transcription_id}", headers={"key": EXAMPLE_AUTH_KEY}
     )
     response_dict = response.get_json()
+    assert response.headers["Content-Type"] == "application/json"
     assert response.status_code == 200
     assert response_dict["settings"] is None
     assert response_dict["model"] is None
@@ -141,6 +144,7 @@ def test_get_transcriptions_without_files(rest_client):
     """Test the get transcriptions endpoint without files"""
     response = rest_client.get("/transcriptions", headers={"key": EXAMPLE_AUTH_KEY})
     assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/json"
     assert response.get_json() == []
 
 
@@ -159,6 +163,7 @@ def test_get_transcriptions_with_files(rest_client, cleanup_data):
         f"/transcriptions/{transcription_id}",
         headers={"key": EXAMPLE_AUTH_KEY},
     )
+    assert response_get.headers["Content-Type"] == "application/json"
     assert response_get.status_code == 200
     response_dict_get = response_get.get_json()
     assert "transcription_id" in response_dict_get
@@ -190,6 +195,7 @@ def test_post_transcription_with_settings_model(rest_client, cleanup_data):
         f"/transcriptions/{transcription_id}", headers={"key": EXAMPLE_AUTH_KEY}
     )
     response_dict = response.get_json()
+    assert response.headers["Content-Type"] == "application/json"
     assert response.status_code == 200
     assert response_dict["settings"] == {"test": "test"}
     assert response_dict["model"] == "tiny"
@@ -222,6 +228,7 @@ def test_post_transc_with_tomany_audio_files_stored_not_including_model(
             content_type="multipart/form-data",
         )
     response_dict = response.get_json()
+    assert response.headers["Content-Type"] == "application/json"
     assert response.status_code == 200
     assert response_dict["status"] == "in_query"
     assert response_dict["transcription_id"] is not None

--- a/src/helper/file_handler.py
+++ b/src/helper/file_handler.py
@@ -8,7 +8,8 @@ class FileHandler:
     """This class handles the reading and writing of JSON files."""
 
     def __init__(self):
-        self.log = Logger("FileHandler", False, Color.YELLOW)
+        #active debug mode to see the logs
+        self.log = Logger("FileHandler", False, Color.BRIGHT_RED)
 
     def read_json(self, file_path):
         """Reads a JSON file and returns the data."""
@@ -17,7 +18,7 @@ class FileHandler:
                 data = json.load(file)
             return data
         except Exception as e:
-            self.log.print_error("Error reading JSON file: " + str(e))
+            self.log.print_log("Error reading JSON file: " + str(e))
             return None
 
     def write_json(self, file_path, data) -> bool:
@@ -27,7 +28,7 @@ class FileHandler:
                 json.dump(data, file)
             return True
         except Exception as e:
-            self.log.print_error("Error writing JSON file: " + str(e))
+            self.log.print_log("Error writing JSON file: " + str(e))
             return False
 
     def create(self, file_path, data) -> bool:
@@ -37,7 +38,7 @@ class FileHandler:
                 json.dump(data, file)
             return True
         except Exception as e:
-            self.log.print_error("Error creating JSON file: " + str(e))
+            self.log.print_log("Error creating JSON file: " + str(e))
             return False
 
     def delete(self, file_path) -> bool:
@@ -46,5 +47,5 @@ class FileHandler:
             os.remove(file_path)
             return True
         except Exception as e:
-            self.log.print_error("Error deleting file: " + str(e))
+            self.log.print_log("Error deleting file: " + str(e))
             return False


### PR DESCRIPTION
Bugs that have been solved:

1. The API-keys are not printed as part of the config when requesting "/" anymore.
2. REST endpoints do now serve as content-type "application/json".
3. File_handler logging is now optional for debugging, so no error throws when requesting a transcription via the GET transcriptions/<id> endpoint that does not exist.


Closes #63 